### PR TITLE
Making Cache and Datasource a bit more like Dict

### DIFF
--- a/src/examples/nooptask.jl
+++ b/src/examples/nooptask.jl
@@ -79,7 +79,7 @@ function DaemonTask.finalize(task::NoOpTaskDetails,
 
     # Arbitrarily delete the first input file from the cache
     if !isempty(task.basic_info.inputs)
-        Datasource.remove!(datasource,
+        Datasource.delete!(datasource,
             DaemonTask.make_key(task, task.basic_info.inputs[1]);
                 only_cache=true)
     end

--- a/src/services/bucketcachedatasource.jl
+++ b/src/services/bucketcachedatasource.jl
@@ -15,12 +15,12 @@ end
 
 function Datasource.get(datasource::BucketCacheDatasourceService,
         key::AbstractString; override_cache::Bool=false)
-    if override_cache || !Cache.haskey(datasource.cache, key)
+    if override_cache || !haskey(datasource.cache, key)
         stream = Bucket.download(datasource.remote, key)
-        Cache.put!(datasource.cache, key, stream)
+        datasource.cache[key] = stream
         close(stream)
     end
-    return Cache.get(datasource.cache, key)
+    return datasource.cache[key]
 end
 
 function Datasource.put!(datasource::BucketCacheDatasourceService,
@@ -28,16 +28,16 @@ function Datasource.put!(datasource::BucketCacheDatasourceService,
         only_cache::Bool=false)
     if new_value != nothing
         seekstart(new_value)
-        Cache.put!(datasource.cache, key, new_value)
+        datasource.cache[key] = new_value
     end
 
-    if !Cache.haskey(datasource.cache, key)
+    if !haskey(datasource.cache, key)
         return false
     end
 
     if !only_cache
         Bucket.upload(datasource.remote,
-            Cache.get(datasource.cache, key), key)
+            datasource.cache[key], key)
     end
     return true
 end
@@ -48,7 +48,7 @@ function Datasource.delete!(datasource::BucketCacheDatasourceService,
         Bucket.delete(datasource.remote, key)
     end
 
-    Cache.delete!(datasource.cache, key)
+    delete!(datasource.cache, key)
 end
 
 function Datasource.clear_cache(datasource::BucketCacheDatasourceService)

--- a/src/services/bucketcachedatasource.jl
+++ b/src/services/bucketcachedatasource.jl
@@ -15,7 +15,7 @@ end
 
 function Datasource.get(datasource::BucketCacheDatasourceService,
         key::AbstractString; override_cache::Bool=false)
-    if override_cache || !Cache.exists(datasource.cache, key)
+    if override_cache || !Cache.haskey(datasource.cache, key)
         stream = Bucket.download(datasource.remote, key)
         Cache.put!(datasource.cache, key, stream)
         close(stream)
@@ -31,7 +31,7 @@ function Datasource.put!(datasource::BucketCacheDatasourceService,
         Cache.put!(datasource.cache, key, new_value)
     end
 
-    if !Cache.exists(datasource.cache, key)
+    if !Cache.haskey(datasource.cache, key)
         return false
     end
 
@@ -42,13 +42,13 @@ function Datasource.put!(datasource::BucketCacheDatasourceService,
     return true
 end
 
-function Datasource.remove!(datasource::BucketCacheDatasourceService,
+function Datasource.delete!(datasource::BucketCacheDatasourceService,
         key::AbstractString; only_cache::Bool=false)
     if !only_cache
         Bucket.delete(datasource.remote, key)
     end
 
-    Cache.remove!(datasource.cache, key)
+    Cache.delete!(datasource.cache, key)
 end
 
 function Datasource.clear_cache(datasource::BucketCacheDatasourceService)

--- a/src/services/cache.jl
+++ b/src/services/cache.jl
@@ -11,7 +11,7 @@ export Service, exists, put!, get, delete!
 
 Returns true if the key is found in the cache.
 """
-function haskey(cache::CacheService, key::AbstractString)
+function Base.haskey(cache::CacheService, key::AbstractString)
     error("exists is unimplemented for $cache")
 end
 
@@ -46,7 +46,7 @@ end
 Delete the cached value for the given key.
 Does nothing if key is not found (this is what Julia `Dict` does)
 """
-function delete!(cache::CacheService, key::AbstractString)
+function Base.delete!(cache::CacheService, key::AbstractString)
     error("delete! is unimplemented for $cache")
 end
 

--- a/src/services/cache.jl
+++ b/src/services/cache.jl
@@ -2,14 +2,16 @@ module Cache
 
 using ...SimpleTasks.Types
 
+import Base
+
 export Service, exists, put!, get, delete!
 
 """
-    exists(cache::CacheService, key::AbstractString)
+    haskey(cache::CacheService, key::AbstractString)
 
 Returns true if the key is found in the cache.
 """
-function exists(cache::CacheService, key::AbstractString)
+function haskey(cache::CacheService, key::AbstractString)
     error("exists is unimplemented for $cache")
 end
 
@@ -21,30 +23,37 @@ Reads the value from IO to store into the cache under the key.
 function put!(cache::CacheService, key::AbstractString, value_io::IO)
     error("put is unimplemented for $cache")
 end
+function Base.setindex!(cache::CacheService, value_io::IO, key::AbstractString)
+    put!(cache, key, value_io)
+end
 
 """
     get(cache::CacheService, key::AbstractString)
 
 Get an IO stream to the object that is cached with this key.
-Returns ```nothing``` if key is not found.
+Throws KeyError if key doesn't exist.
 """
 function get(cache::CacheService, key::AbstractString)
     error("get is unimplemented for $cache")
 end
+function Base.getindex(cache::CacheService, key::AbstractString)
+    get(cache, key)
+end
 
 """
-    remove!(cache::CacheService, key::AbstractString)
+    delete!(cache::CacheService, key::AbstractString)
 
-Remove the cached value for the given key.
+Delete the cached value for the given key.
+Does nothing if key is not found (this is what Julia `Dict` does)
 """
-function remove!(cache::CacheService, key::AbstractString)
-    error("remove! is unimplemented for $cache")
+function delete!(cache::CacheService, key::AbstractString)
+    error("delete! is unimplemented for $cache")
 end
 
 """
     clear!(cache::CacheService)
 
-Remove all cached items.
+Delete all cached items.
 """
 function clear!(cache::CacheService)
     error("clear! is unimplemented for $cache")

--- a/src/services/datasource.jl
+++ b/src/services/datasource.jl
@@ -2,6 +2,8 @@ module Datasource
 
 using ...SimpleTasks.Types
 
+import Base
+
 export get, put
 
 """
@@ -13,6 +15,9 @@ allow skipping any cached values.
 function get(datasource::DatasourceService, key::AbstractString;
         override_cache::Bool=false)
     error("get is not implemented for $datasource")
+end
+function Base.getindex(datasource::DatasourceService, key::AbstractString)
+    get(datasource, key)
 end
 
 """
@@ -29,6 +34,10 @@ function get{String <: AbstractString}(datasource::DatasourceService,
     return pmap((key) -> Datasource.get(datasource, key;
         override_cache=override_cache), keys)
 end
+function Base.getindex{String <: AbstractString}(datasource::DatasourceService,
+        keys::Array{String, 1})
+    get(datasource, keys)
+end
 
 """
     put!(datasource::DatasourceService, key::AbstractString,
@@ -44,6 +53,10 @@ not specified.
 function put!(datasource::DatasourceService, key::AbstractString,
         new_value::Union{IO, Void}=nothing; only_cache::Bool=false)
     error("put! is not implemented for $datasource")
+end
+function Base.setindex!(datasource::DatasourceService, key::AbstractString,
+        new_value::Union{IO, Void}=nothing; only_cache::Bool=false)
+    put!(datasource, key, new_value)
 end
 
 """
@@ -66,6 +79,11 @@ function put!{String <: AbstractString, I <: Union{IO, Void}}(
     return pmap((index) -> Datasource.put!(datasource, keys[index],
         new_values[index]; only_cache=only_cache), 1:length(keys))
 end
+function Base.setindex!{String <: AbstractString, I <: Union{IO, Void}}(
+        datasource::DatasourceService, keys::Array{String, 1},
+        new_values::Array{I, 1}; only_cache::Bool=false)
+    put!(datasource, keys, new_values)
+end
 
 function put!{String <: AbstractString}(
         datasource::DatasourceService, keys::Array{String, 1};
@@ -78,22 +96,22 @@ end
     clear!(datasource::DatasourceService, key::AbstractString};
         only_cache::Bool=false)
 
-Remove the value from the datasource. Optionally only remove from cache.
+Delete the value from the datasource. Optionally only delete from cache.
 """
-function remove!(datasource::DatasourceService, key::AbstractString;
+function delete!(datasource::DatasourceService, key::AbstractString;
         only_cache::Bool=false)
-    error("remove! is not implemented for $datasource")
+    error("delete! is not implemented for $datasource")
 end
 
 """
-    remove!{String <: AbstractString}(datasource::DatasourceService,
+    delete!{String <: AbstractString}(datasource::DatasourceService,
         keys::Array{String, 1}; only_cache::Bool=false)
 
-Remove multiple keys from the datasource. Optionally only remove from cache
+Delete multiple keys from the datasource. Optionally only delete from cache
 """
-function remove!{String <: AbstractString}(datasource::DatasourceService,
+function delete!{String <: AbstractString}(datasource::DatasourceService,
         keys::Array{String, 1}; only_cache::Bool=false)
-    return pmap((key) -> Datasource.remove!(datasource, key;
+    return pmap((key) -> Datasource.delete!(datasource, key;
         only_cache=only_cache), keys)
 end
 

--- a/src/services/filesystemcache.jl
+++ b/src/services/filesystemcache.jl
@@ -35,7 +35,7 @@ function create_path(full_path_file_name::AbstractString)
     end
 end
 
-function Cache.exists(cache::FileSystemCacheService, key::AbstractString)
+function Cache.haskey(cache::FileSystemCacheService, key::AbstractString)
     filename = to_filename(cache, key)
     return isfile(filename) && isreadable(filename)
 end
@@ -71,22 +71,24 @@ function Cache.put!(cache::FileSystemCacheService, key::AbstractString,
     # if the outcome of the put resulted in an empty file, then remove it
     # from the cache
     close(filestream)
-    if Cache.exists(cache, key) && stat(filename).size == 0
+    if Cache.haskey(cache, key) && stat(filename).size == 0
         rm(filename)
         error("Tried to cache an empty file $key into $filename")
     end
 end
 
 function Cache.get(cache::FileSystemCacheService, key::AbstractString)
-    if Cache.exists(cache, key)
+    if Cache.haskey(cache, key)
         return open(to_filename(cache, key), "r")
     else
-        return nothing
+        throw(KeyError(key))
     end
 end
 
-function Cache.remove!(cache::FileSystemCacheService, key::AbstractString)
-    rm(to_filename(cache, key))
+function Cache.delete!(cache::FileSystemCacheService, key::AbstractString)
+    if Cache.haskey(cache, key)
+        rm(to_filename(cache, key))
+    end
 end
 
 function Cache.clear!(cache::FileSystemCacheService)

--- a/test/services/test_bucketcachedatasource.jl
+++ b/test/services/test_bucketcachedatasource.jl
@@ -475,7 +475,7 @@ function test_put_multi_new_value_only_cache()
 
 end
 
-function test_remove()
+function test_delete()
     key = "somekey"
 
     bucket_text = "mock contents"
@@ -494,14 +494,14 @@ function test_remove()
     cache = MockCacheService(cache_values)
     datasource = BucketCacheDatasourceService(bucket, cache)
 
-    Datasource.remove!(datasource, key)
+    Datasource.delete!(datasource, key)
 
-    # ensure that the value was removed from both bucket and cache
+    # ensure that the value was deleted from both bucket and cache
     @test !haskey(bucket.mockFiles, key)
     @test !haskey(cache.mockValues, key)
 end
 
-function test_remove_multi()
+function test_delete_multi()
     key1 = "somekey1"
 
     bucket_text1 = "mock contents"
@@ -534,9 +534,9 @@ function test_remove_multi()
     cache = MockCacheService(cache_values)
     datasource = BucketCacheDatasourceService(bucket, cache)
 
-    Datasource.remove!(datasource, [key1, key2])
+    Datasource.delete!(datasource, [key1, key2])
 
-    # ensure that all values were removed from both bucket and cache
+    # ensure that all values were deleted from both bucket and cache
     @test !haskey(bucket.mockFiles, key1)
     @test !haskey(cache.mockValues, key1)
 
@@ -544,7 +544,7 @@ function test_remove_multi()
     @test !haskey(cache.mockValues, key2)
 end
 
-function test_remove_cache_only()
+function test_delete_cache_only()
     key = "somekey"
 
     bucket_text = "mock contents"
@@ -563,9 +563,9 @@ function test_remove_cache_only()
     cache = MockCacheService(cache_values)
     datasource = BucketCacheDatasourceService(bucket, cache)
 
-    Datasource.remove!(datasource, key; only_cache=true)
+    Datasource.delete!(datasource, key; only_cache=true)
 
-    # ensure that the value was removed from both bucket and cache
+    # ensure that the value was deleted from both bucket and cache
     @test haskey(bucket.mockFiles, key)
     @test !haskey(cache.mockValues, key)
 end
@@ -599,7 +599,7 @@ function test_clear_cache()
 
     Datasource.clear_cache(datasource)
 
-    # ensure that the value was removed only from cache
+    # ensure that the value was deleted only from cache
     @test haskey(bucket.mockFiles, key1)
 
     @test !haskey(cache.mockValues, key1)
@@ -622,9 +622,9 @@ function __init__()
     test_put_multi_new_value()
     test_put_not_exist_new_value()
 
-    test_remove()
-    test_remove_multi()
-    test_remove_cache_only()
+    test_delete()
+    test_delete_multi()
+    test_delete_cache_only()
 
     test_clear_cache()
 end

--- a/test/services/test_filesystemcache.jl
+++ b/test/services/test_filesystemcache.jl
@@ -37,7 +37,7 @@ function test_has_key()
     file = open(full_path_file_name, "w")
     close(file)
     cache = make_valid_file_system_cache()
-    @test Cache.haskey(cache, filename)
+    @test haskey(cache, filename)
     rm(full_path_file_name)
 end
 
@@ -45,7 +45,7 @@ function test_not_exist()
     filename = "testfileDOES NOT EXIST"
     full_path_file_name = "$TEST_BASE_DIRECTORY/$filename"
     cache = make_valid_file_system_cache()
-    @test !Cache.haskey(cache, filename)
+    @test !haskey(cache, filename)
 end
 
 function test_put()
@@ -53,7 +53,7 @@ function test_put()
     test_string = "TEST"
     buffer = IOBuffer(test_string)
     cache = make_valid_file_system_cache()
-    Cache.put!(cache, filename, buffer)
+    cache[filename] = buffer
     file = open("$TEST_BASE_DIRECTORY/$filename", "r")
     @test isreadable(file)
     @test readall(file) == test_string
@@ -65,7 +65,7 @@ function test_put_path()
     test_string = "TEST"
     buffer = IOBuffer(test_string)
     cache = make_valid_file_system_cache()
-    Cache.put!(cache, filename, buffer)
+    cache[filename] = buffer
     file = open("$TEST_BASE_DIRECTORY/$filename", "r")
     @test isreadable(file)
     @test readall(file) == test_string
@@ -102,8 +102,8 @@ function test_delete()
     test_string = "TEST"
     buffer = IOBuffer(test_string)
     cache = make_valid_file_system_cache()
-    Cache.put!(cache, filename, buffer)
-    Cache.delete!(cache, filename)
+    cache[filename] = buffer
+    delete!(cache, filename)
     @test !isfile("$TEST_BASE_DIRECTORY/$filename")
 end
 
@@ -119,8 +119,8 @@ function test_delete_path()
     test_string = "TEST"
     buffer = IOBuffer(test_string)
     cache = make_valid_file_system_cache()
-    Cache.put!(cache, filename, buffer)
-    Cache.delete!(cache, filename)
+    cache[filename] = buffer
+    delete!(cache, filename)
     @test !isfile("$TEST_BASE_DIRECTORY/$filename")
 end
 
@@ -135,8 +135,8 @@ function test_clear()
     test_string2 = "TEST2"
     buffer2 = IOBuffer(test_string2)
 
-    Cache.put!(cache, filename1, buffer1)
-    Cache.put!(cache, filename2, buffer2)
+    cache[filename1] = buffer1
+    cache[filename2] = buffer2
     Cache.clear!(cache)
 
     @test isempty(readdir(cache.base_directory))

--- a/test/services/test_filesystemcache.jl
+++ b/test/services/test_filesystemcache.jl
@@ -31,13 +31,13 @@ function test_to_filename_sanitized()
         "$TEST_BASE_DIRECTORY///.ssh/id_rsa"
 end
 
-function test_exists()
+function test_has_key()
     filename = "testfile"
     full_path_file_name = "$TEST_BASE_DIRECTORY/$filename"
     file = open(full_path_file_name, "w")
     close(file)
     cache = make_valid_file_system_cache()
-    @test Cache.exists(cache, filename)
+    @test Cache.haskey(cache, filename)
     rm(full_path_file_name)
 end
 
@@ -45,7 +45,7 @@ function test_not_exist()
     filename = "testfileDOES NOT EXIST"
     full_path_file_name = "$TEST_BASE_DIRECTORY/$filename"
     cache = make_valid_file_system_cache()
-    @test !Cache.exists(cache, filename)
+    @test !Cache.haskey(cache, filename)
 end
 
 function test_put()
@@ -91,30 +91,37 @@ function test_get()
     close(buffer)
 end
 
-function test_get_not_exists()
+function test_get_not_has_key()
     filename = "testfileDOES NOT EXIST"
     cache = make_valid_file_system_cache()
-    buffer = Cache.get(cache, filename)
-    @test buffer == nothing
+    @test_throws KeyError Cache.get(cache, filename)
 end
 
-function test_remove()
+function test_delete()
     filename = "key"
     test_string = "TEST"
     buffer = IOBuffer(test_string)
     cache = make_valid_file_system_cache()
     Cache.put!(cache, filename, buffer)
-    Cache.remove!(cache, filename)
+    Cache.delete!(cache, filename)
     @test !isfile("$TEST_BASE_DIRECTORY/$filename")
 end
 
-function test_remove_path()
+function test_delete_not_has_key()
+    filename = "keyDOES NOT EXIST"
+    cache = make_valid_file_system_cache()
+    # should not throw
+    Cache.delete!(cache, filename)
+end
+
+function test_delete_path()
     filename = "a/b/c/key"
     test_string = "TEST"
     buffer = IOBuffer(test_string)
     cache = make_valid_file_system_cache()
     Cache.put!(cache, filename, buffer)
-    Cache.remove!(cache, filename)
+    Cache.delete!(cache, filename)
+    @test !isfile("$TEST_BASE_DIRECTORY/$filename")
 end
 
 function test_clear()
@@ -143,17 +150,18 @@ function __init__()
     test_to_filename()
     test_to_filename_sanitized()
 
-    test_exists()
+    test_has_key()
     test_not_exist()
 
     test_put()
     test_put_path()
 
     test_get()
-    test_get_not_exists()
+    test_get_not_has_key()
 
-    test_remove()
-    test_remove_path()
+    test_delete()
+    test_delete_not_has_key()
+    test_delete_path()
 
     test_clear()
 end

--- a/test/utils/mockservices.jl
+++ b/test/utils/mockservices.jl
@@ -52,7 +52,7 @@ type MockCacheService <: CacheService
     mockValues::Dict{AbstractString, IO}
 end
 MockCacheService() = MockCacheService(Dict())
-function Cache.exists(cache::MockCacheService, key::AbstractString)
+function Cache.haskey(cache::MockCacheService, key::AbstractString)
     return haskey(cache.mockValues, key)
 end
 function Cache.put!(cache::MockCacheService, key::AbstractString,
@@ -71,7 +71,7 @@ function Cache.get(cache::MockCacheService, key::AbstractString)
         return nothing
     end
 end
-function Cache.remove!(cache::MockCacheService, key::AbstractString)
+function Cache.delete!(cache::MockCacheService, key::AbstractString)
     delete!(cache.mockValues, key)
 end
 function Cache.clear!(cache::MockCacheService)
@@ -103,7 +103,7 @@ function Datasource.put!(datasource::MockDatasourceService, key::AbstractString,
         datasource.mockSource[key] = data
     end
 end
-function Datasource.remove!(datasource::MockDatasourceService,
+function Datasource.delete!(datasource::MockDatasourceService,
     key::AbstractString; only_cache::Bool=false)
     delete!(datasource.mockSource, key)
 end


### PR DESCRIPTION
Cache rm no longer throws an error when key doesn't exist ( similar to julia's Dict)
Cache get throws a key error when key doesn't exist (similar to julia's Dict)

Support for `cache[key]` function